### PR TITLE
subtree net-rpc-msgpack

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 HashiCorp, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # net-rpc-msgpackrpc
 
 This library provides the same functions as `net/rpc/jsonrpc` but for
-communicating with [MessagePack](http://msgpack.org/) instead.
+communicating with [MessagePack](http://msgpack.org/) instead. The library
+is modeled directly after the Go standard library so it should be easy to
+use and obvious.
+
+See the [GoDoc](http://godoc.org/github.com/hashicorp/net-rpc-msgpackrpc) for
+API documentation.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# net-rpc-msgpackrpc
+
+This library provides the same functions as `net/rpc/jsonrpc` but for
+communicating with [MessagePack](http://msgpack.org/) instead.

--- a/client.go
+++ b/client.go
@@ -1,0 +1,36 @@
+package msgpackrpc
+
+import (
+	"net/rpc"
+	"sync/atomic"
+)
+
+var (
+	// nextCallSeq is used to assign a unique sequence number
+	// to each call made with CallWithCodec
+	nextCallSeq uint64
+)
+
+// CallWithCodec is used to perform the same actions as rpc.Client.Call but
+// in a much cheaper way. It assumes the underlying connection is not being
+// shared with multiple concurrent RPCs. The request/response must be syncronous.
+func CallWithCodec(cc rpc.ClientCodec, method string, args interface{}, resp interface{}) error {
+	request := rpc.Request{
+		Seq:           atomic.AddUint64(&nextCallSeq, 1),
+		ServiceMethod: method,
+	}
+	if err := cc.WriteRequest(&request, args); err != nil {
+		return err
+	}
+	var response rpc.Response
+	if err := cc.ReadResponseHeader(&response); err != nil {
+		return err
+	}
+	if err := cc.ReadResponseBody(resp); err != nil {
+		return err
+	}
+	if response.Error != "" {
+		return rpc.ServerError(response.Error)
+	}
+	return nil
+}

--- a/client.go
+++ b/client.go
@@ -26,11 +26,12 @@ func CallWithCodec(cc rpc.ClientCodec, method string, args interface{}, resp int
 	if err := cc.ReadResponseHeader(&response); err != nil {
 		return err
 	}
+	if response.Error != "" {
+		cc.ReadResponseBody(nil)
+		return rpc.ServerError(response.Error)
+	}
 	if err := cc.ReadResponseBody(resp); err != nil {
 		return err
-	}
-	if response.Error != "" {
-		return rpc.ServerError(response.Error)
 	}
 	return nil
 }

--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,114 @@
+package msgpackrpc
+
+import (
+	"bufio"
+	"io"
+	"net/rpc"
+	"sync"
+
+	"github.com/hashicorp/go-msgpack/codec"
+)
+
+var (
+	// msgpackHandle is shared handle for decoding
+	msgpackHandle = &codec.MsgpackHandle{}
+)
+
+// MsgpackCodec implements the rpc.ClientCodec and rpc.ServerCodec
+// using the msgpack encoding
+type MsgpackCodec struct {
+	closed    bool
+	conn      io.ReadWriteCloser
+	bufR      *bufio.Reader
+	bufW      *bufio.Writer
+	enc       *codec.Encoder
+	dec       *codec.Decoder
+	writeLock sync.Mutex
+}
+
+// NewCodec returns a MsgpackCodec that can be used as either
+// a Client or Server rpc Codec. It also provides controls for
+// enabling and disabling buffering for both reads and writes.
+func NewCodec(bufReads, bufWrites bool, conn io.ReadWriteCloser) *MsgpackCodec {
+	cc := &MsgpackCodec{
+		conn: conn,
+	}
+	if bufReads {
+		cc.bufR = bufio.NewReader(conn)
+		cc.dec = codec.NewDecoder(cc.bufR, msgpackHandle)
+	} else {
+		cc.dec = codec.NewDecoder(cc.conn, msgpackHandle)
+	}
+	if bufWrites {
+		cc.bufW = bufio.NewWriter(conn)
+		cc.enc = codec.NewEncoder(cc.bufW, msgpackHandle)
+	} else {
+		cc.enc = codec.NewEncoder(cc.conn, msgpackHandle)
+	}
+	return cc
+}
+
+func (cc *MsgpackCodec) ReadRequestHeader(r *rpc.Request) error {
+	return cc.read(r)
+}
+
+func (cc *MsgpackCodec) ReadRequestBody(out interface{}) error {
+	return cc.read(out)
+}
+
+func (cc *MsgpackCodec) WriteResponse(r *rpc.Response, body interface{}) error {
+	cc.writeLock.Lock()
+	defer cc.writeLock.Unlock()
+	return cc.write(r, body)
+}
+
+func (cc *MsgpackCodec) ReadResponseHeader(r *rpc.Response) error {
+	return cc.read(r)
+}
+
+func (cc *MsgpackCodec) ReadResponseBody(out interface{}) error {
+	return cc.read(out)
+}
+
+func (cc *MsgpackCodec) WriteRequest(r *rpc.Request, body interface{}) error {
+	cc.writeLock.Lock()
+	defer cc.writeLock.Unlock()
+	return cc.write(r, body)
+}
+
+func (cc *MsgpackCodec) Close() error {
+	if cc.closed {
+		return nil
+	}
+	cc.closed = true
+	return cc.conn.Close()
+}
+
+func (cc *MsgpackCodec) write(obj1, obj2 interface{}) (err error) {
+	if cc.closed {
+		return io.EOF
+	}
+	if err = cc.enc.Encode(obj1); err != nil {
+		return
+	}
+	if err = cc.enc.Encode(obj2); err != nil {
+		return
+	}
+	if cc.bufW != nil {
+		return cc.bufW.Flush()
+	}
+	return
+}
+
+func (cc *MsgpackCodec) read(obj interface{}) (err error) {
+	if cc.closed {
+		return io.EOF
+	}
+
+	// If nil is passed in, we should still attempt to read content to nowhere.
+	if obj == nil {
+		var obj2 interface{}
+		return cc.dec.Decode(&obj2)
+	}
+	return cc.dec.Decode(obj)
+}

--- a/codec.go
+++ b/codec.go
@@ -26,9 +26,9 @@ type MsgpackCodec struct {
 	writeLock sync.Mutex
 }
 
-// NewCodec returns a MsgpackCodec that can be used as either
-// a Client or Server rpc Codec. It also provides controls for
-// enabling and disabling buffering for both reads and writes.
+// NewCodec returns a MsgpackCodec that can be used as either a Client or Server
+// rpc Codec using a default handle. It also provides controls for enabling and
+// disabling buffering for both reads and writes.
 func NewCodec(bufReads, bufWrites bool, conn io.ReadWriteCloser) *MsgpackCodec {
 	cc := &MsgpackCodec{
 		conn: conn,
@@ -44,6 +44,29 @@ func NewCodec(bufReads, bufWrites bool, conn io.ReadWriteCloser) *MsgpackCodec {
 		cc.enc = codec.NewEncoder(cc.bufW, msgpackHandle)
 	} else {
 		cc.enc = codec.NewEncoder(cc.conn, msgpackHandle)
+	}
+	return cc
+}
+
+// NewCodecFromHandle returns a MsgpackCodec that can be used as either a Client
+// or Server rpc Codec using the passed handle. It also provides controls for
+// enabling and disabling buffering for both reads and writes.
+func NewCodecFromHandle(bufReads, bufWrites bool, conn io.ReadWriteCloser,
+	h *codec.MsgpackHandle) *MsgpackCodec {
+	cc := &MsgpackCodec{
+		conn: conn,
+	}
+	if bufReads {
+		cc.bufR = bufio.NewReader(conn)
+		cc.dec = codec.NewDecoder(cc.bufR, h)
+	} else {
+		cc.dec = codec.NewDecoder(cc.conn, h)
+	}
+	if bufWrites {
+		cc.bufW = bufio.NewWriter(conn)
+		cc.enc = codec.NewEncoder(cc.bufW, h)
+	} else {
+		cc.enc = codec.NewEncoder(cc.conn, h)
 	}
 	return cc
 }

--- a/codec.go
+++ b/codec.go
@@ -30,22 +30,7 @@ type MsgpackCodec struct {
 // rpc Codec using a default handle. It also provides controls for enabling and
 // disabling buffering for both reads and writes.
 func NewCodec(bufReads, bufWrites bool, conn io.ReadWriteCloser) *MsgpackCodec {
-	cc := &MsgpackCodec{
-		conn: conn,
-	}
-	if bufReads {
-		cc.bufR = bufio.NewReader(conn)
-		cc.dec = codec.NewDecoder(cc.bufR, msgpackHandle)
-	} else {
-		cc.dec = codec.NewDecoder(cc.conn, msgpackHandle)
-	}
-	if bufWrites {
-		cc.bufW = bufio.NewWriter(conn)
-		cc.enc = codec.NewEncoder(cc.bufW, msgpackHandle)
-	} else {
-		cc.enc = codec.NewEncoder(cc.conn, msgpackHandle)
-	}
-	return cc
+	return NewCodecFromHandle(bufReads, bufWrites, conn, msgpackHandle)
 }
 
 // NewCodecFromHandle returns a MsgpackCodec that can be used as either a Client

--- a/msgpackrpc.go
+++ b/msgpackrpc.go
@@ -1,3 +1,6 @@
+// Package msgpackrpc implements a MessagePack-RPC ClientCodec and ServerCodec
+// for the rpc package, using the same API as the Go standard library
+// for jsonrpc.
 package msgpackrpc
 
 import (

--- a/msgpackrpc.go
+++ b/msgpackrpc.go
@@ -4,7 +4,6 @@
 package msgpackrpc
 
 import (
-	"github.com/hashicorp/go-msgpack/codec"
 	"io"
 	"net"
 	"net/rpc"
@@ -27,14 +26,12 @@ func NewClient(conn io.ReadWriteCloser) *rpc.Client {
 
 // NewClientCodec returns a new rpc.ClientCodec using MessagePack-RPC on conn.
 func NewClientCodec(conn io.ReadWriteCloser) rpc.ClientCodec {
-	handle := new(codec.MsgpackHandle)
-	return codec.GoRpc.ClientCodec(conn, handle)
+	return NewCodec(true, true, conn)
 }
 
 // NewServerCodec returns a new rpc.ServerCodec using MessagePack-RPC on conn.
 func NewServerCodec(conn io.ReadWriteCloser) rpc.ServerCodec {
-	handle := new(codec.MsgpackHandle)
-	return codec.GoRpc.ServerCodec(conn, handle)
+	return NewCodec(true, true, conn)
 }
 
 // ServeConn runs the MessagePack-RPC server on a single connection. ServeConn

--- a/msgpackrpc.go
+++ b/msgpackrpc.go
@@ -1,0 +1,42 @@
+package msgpackrpc
+
+import (
+	"github.com/ugorji/go/codec"
+	"io"
+	"net"
+	"net/rpc"
+)
+
+// Dial connects to a MessagePack-RPC server at the specified network address.
+func Dial(network, address string) (*rpc.Client, error) {
+	conn, err := net.Dial(network, address)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(conn), err
+}
+
+// NewClient returns a new rpc.Client to handle requests to the set of
+// services at the other end of the connection.
+func NewClient(conn io.ReadWriteCloser) *rpc.Client {
+	return rpc.NewClientWithCodec(NewClientCodec(conn))
+}
+
+// NewClientCodec returns a new rpc.ClientCodec using MessagePack-RPC on conn.
+func NewClientCodec(conn io.ReadWriteCloser) rpc.ClientCodec {
+	handle := new(codec.MsgpackHandle)
+	return codec.GoRpc.ClientCodec(conn, handle)
+}
+
+// NewServerCodec returns a new rpc.ServerCodec using MessagePack-RPC on conn.
+func NewServerCodec(conn io.ReadWriteCloser) rpc.ServerCodec {
+	handle := new(codec.MsgpackHandle)
+	return codec.GoRpc.ServerCodec(conn, handle)
+}
+
+// ServeConn runs the MessagePack-RPC server on a single connection. ServeConn
+// blocks, serving the connection until the client hangs up. The caller
+// typically invokes ServeConn in a go statement.
+func ServeConn(conn io.ReadWriteCloser) {
+	rpc.ServeCodec(NewServerCodec(conn))
+}

--- a/msgpackrpc.go
+++ b/msgpackrpc.go
@@ -4,7 +4,7 @@
 package msgpackrpc
 
 import (
-	"github.com/ugorji/go/codec"
+	"github.com/hashicorp/go-msgpack/codec"
 	"io"
 	"net"
 	"net/rpc"

--- a/msgpackrpc_test.go
+++ b/msgpackrpc_test.go
@@ -1,0 +1,1 @@
+package msgpackrpc


### PR DESCRIPTION
#### Overview

This PR adds [`net-rpc-msgpack`](https://github.com/hashicorp/net-rpc-msgpackrpc) as a subtree to this project. Cmd used:

```
git subtree add --prefix net-rpc-msgpackrpc https://github.com/hashicorp/net-rpc-msgpackrpc.git  master
```

#### Notes
* This is isomorphic to #1; 