### PR TITLE
Fix codec tests

### DIFF
--- a/go-msgpack/codec/z_helper_test.go
+++ b/go-msgpack/codec/z_helper_test.go
@@ -11,8 +11,9 @@ package codec
 
 import (
 	"errors"
-	"reflect"
 	"flag"
+	"os"
+	"reflect"
 	"testing"
 )
 
@@ -24,9 +25,13 @@ var (
 func init() {
 	testInitFlags()
 	benchInitFlags()
+}
+
+func TestMain(m *testing.M) {
 	flag.Parse()
 	testInit()
 	benchInit()
+	os.Exit(m.Run())
 }
 
 func checkErrT(t *testing.T, err error) {


### PR DESCRIPTION
Some context in https://github.com/golang/go/issues/21051

At some point around go1.12/go1.13 the testing package was changed in such a way
that calling `flag.Parse` from an `init()` function would cause this
problem.

I believe the correct workaround is to instead call `flag.Parse` from
`TestMain`, which this commit does.

With this commit tests will once again run with the latest Go version.