### PR TITLE
Import the local copy of net/rpc

### DIFF
--- a/go-msgpack/codec/codecs_test.go
+++ b/go-msgpack/codec/codecs_test.go
@@ -24,7 +24,7 @@ import (
 	"io/ioutil"
 	"math"
 	"net"
-	"net/rpc"
+	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/go-msgpack/codec/codecs_test.go
+++ b/go-msgpack/codec/codecs_test.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"math"
 	"net"
-	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,6 +33,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul-net-rpc/net/rpc"
 )
 
 type testVerifyArg int

--- a/go-msgpack/codec/ext_dep_test.go
+++ b/go-msgpack/codec/ext_dep_test.go
@@ -1,4 +1,5 @@
-//+build ignore
+//go:build ignore
+// +build ignore
 
 // NOTE (Jeff Mitchell): I'm disabling this for now as this package never
 // changes, but leaving this file active causes go mod to pull in some very

--- a/go-msgpack/codec/msgpack.go
+++ b/go-msgpack/codec/msgpack.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 )
 

--- a/go-msgpack/codec/msgpack.go
+++ b/go-msgpack/codec/msgpack.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net/rpc"
+	"github.com/hashicorp/consul-net-rpc/net/rpc"
 )
 
 const (

--- a/go-msgpack/codec/rpc.go
+++ b/go-msgpack/codec/rpc.go
@@ -6,7 +6,7 @@ package codec
 import (
 	"bufio"
 	"io"
-	"net/rpc"
+	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"sync"
 )
 

--- a/go-msgpack/codec/rpc.go
+++ b/go-msgpack/codec/rpc.go
@@ -6,8 +6,9 @@ package codec
 import (
 	"bufio"
 	"io"
-	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"sync"
+
+	"github.com/hashicorp/consul-net-rpc/net/rpc"
 )
 
 // Rpc provides a rpc Server or Client Codec for rpc communication.

--- a/net-rpc-msgpackrpc/client.go
+++ b/net-rpc-msgpackrpc/client.go
@@ -2,9 +2,9 @@ package msgpackrpc
 
 import (
 	"errors"
-	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"sync/atomic"
 
+	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"github.com/hashicorp/go-multierror"
 )
 

--- a/net-rpc-msgpackrpc/client.go
+++ b/net-rpc-msgpackrpc/client.go
@@ -2,7 +2,7 @@ package msgpackrpc
 
 import (
 	"errors"
-	"net/rpc"
+	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"sync/atomic"
 
 	"github.com/hashicorp/go-multierror"

--- a/net-rpc-msgpackrpc/codec.go
+++ b/net-rpc-msgpackrpc/codec.go
@@ -3,10 +3,10 @@ package msgpackrpc
 import (
 	"bufio"
 	"io"
-	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"sync"
 
 	"github.com/hashicorp/consul-net-rpc/go-msgpack/codec"
+	"github.com/hashicorp/consul-net-rpc/net/rpc"
 )
 
 var (

--- a/net-rpc-msgpackrpc/codec.go
+++ b/net-rpc-msgpackrpc/codec.go
@@ -3,7 +3,7 @@ package msgpackrpc
 import (
 	"bufio"
 	"io"
-	"net/rpc"
+	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"sync"
 
 	"github.com/hashicorp/consul-net-rpc/go-msgpack/codec"

--- a/net-rpc-msgpackrpc/msgpackrpc.go
+++ b/net-rpc-msgpackrpc/msgpackrpc.go
@@ -6,6 +6,7 @@ package msgpackrpc
 import (
 	"io"
 	"net"
+
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 )
 

--- a/net-rpc-msgpackrpc/msgpackrpc.go
+++ b/net-rpc-msgpackrpc/msgpackrpc.go
@@ -6,7 +6,7 @@ package msgpackrpc
 import (
 	"io"
 	"net"
-	"net/rpc"
+	"github.com/hashicorp/consul-net-rpc/net/rpc"
 )
 
 // Dial connects to a MessagePack-RPC server at the specified network address.


### PR DESCRIPTION

First commit done with:

```sh
git grep -l '"net/rpc"' | xargs sed -i -e 's|"net/rpc"|"github.com/hashicorp/consul-net-rpc/net/rpc"|'
```

Second commit done with:
```sh
find . -name *.go | xargs goimports -w
```

Manually fixed `codec.go` and `client.go` since it did not group the imports correctly for those two.