### PR TITLE
add intercept support as a fn type

### DIFF
--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -519,10 +519,9 @@ func (server *Server) ServeRequest(codec ServerCodec) error {
 	}
 
 	handler :=  func() {
-		service, mtype, req, argv, replyv := service, mtype, req, argv, replyv // capture
-
 		service.call(server, sending, nil, mtype, req, argv, replyv, codec)
 	}
+
 	if server.serverServiceCallInterceptor != nil {
 		server.serverServiceCallInterceptor(mtype.method.Name, argv, replyv, handler)
 	} else {

--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -217,8 +217,7 @@ func WithServerServiceCallInterceptor(interceptor ServerServiceCallInterceptor) 
 
 // ServerServiceCallInterceptor acts a middleware hook on the server side of the RPC call. The interceptor must
 // invoke the handler argument for the RPC request to continue.
-// ServiceCallInterceptor
-type ServerServiceCallInterceptor func(serviceMethod string, argv, replyv reflect.Value, handler func())
+type ServerServiceCallInterceptor func(reqServiceMethod string, argv, replyv reflect.Value, handler func())
 
 // DefaultServer is the default instance of *Server.
 var DefaultServer = NewServer()
@@ -523,7 +522,7 @@ func (server *Server) ServeRequest(codec ServerCodec) error {
 	}
 
 	if server.serverServiceCallInterceptor != nil {
-		server.serverServiceCallInterceptor(mtype.method.Name, argv, replyv, handler)
+		server.serverServiceCallInterceptor(req.ServiceMethod, argv, replyv, handler)
 	} else {
 		handler()
 	}

--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -197,7 +197,7 @@ type Server struct {
 
 // NewServer returns a new Server.
 func NewServer() *Server {
-	return &Server{}
+	return NewServerWithOpts()
 }
 
 // NewServerWithOpts returns a new Server with the following functional options.

--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -517,7 +517,7 @@ func (server *Server) ServeRequest(codec ServerCodec) error {
 		return err
 	}
 
-	handler :=  func() {
+	handler := func() {
 		service.call(server, sending, nil, mtype, req, argv, replyv, codec)
 	}
 

--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -192,7 +192,7 @@ type Server struct {
 	respLock   sync.Mutex // protects freeResp
 	freeResp   *Response
 
-	serverInterceptor ServerInterceptor
+	serverServiceCallInterceptor ServerServiceCallInterceptor
 }
 
 // NewServer returns a new Server.
@@ -209,15 +209,16 @@ func NewServerWithOpts(options... func(*Server)) *Server {
 	return s
 }
 
-func WithServerInterceptor(interceptor ServerInterceptor) func(*Server) {
+func WithServerServiceCallInterceptor(interceptor ServerServiceCallInterceptor) func(*Server) {
 	return func(s *Server) {
-		s.serverInterceptor = interceptor
+		s.serverServiceCallInterceptor = interceptor
 	}
 }
 
-// ServerInterceptor acts a middleware hook on the server side of the RPC call. The interceptor must
+// ServerServiceCallInterceptor acts a middleware hook on the server side of the RPC call. The interceptor must
 // invoke the handler argument for the RPC request to continue.
-type ServiceCallInterceptor func(serviceMethod string, argv, replyv reflect.Value, handler func())
+// ServiceCallInterceptor
+type ServerServiceCallInterceptor func(serviceMethod string, argv, replyv reflect.Value, handler func())
 
 // DefaultServer is the default instance of *Server.
 var DefaultServer = NewServer()
@@ -522,8 +523,8 @@ func (server *Server) ServeRequest(codec ServerCodec) error {
 
 		service.call(server, sending, nil, mtype, req, argv, replyv, codec)
 	}
-	if server.serverInterceptor != nil {
-		server.serverInterceptor(mtype.method.Name, argv, replyv, handler)
+	if server.serverServiceCallInterceptor != nil {
+		server.serverServiceCallInterceptor(mtype.method.Name, argv, replyv, handler)
 	} else {
 		handler()
 	}

--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -217,7 +217,7 @@ func WithServerInterceptor(interceptor ServerInterceptor) func(*Server) {
 
 // ServerInterceptor acts a middleware hook on the server side of the RPC call. The interceptor must
 // invoke the handler argument for the RPC request to continue.
-type ServerInterceptor func(serviceMethod string, argv, replyv reflect.Value, handler func())
+type ServiceCallInterceptor func(serviceMethod string, argv, replyv reflect.Value, handler func())
 
 // DefaultServer is the default instance of *Server.
 var DefaultServer = NewServer()

--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -201,7 +201,7 @@ func NewServer() *Server {
 }
 
 // NewServerWithOpts returns a new Server with the following functional options.
-func NewServerWithOpts(options... func(*Server)) *Server {
+func NewServerWithOpts(options ...func(*Server)) *Server {
 	s := &Server{}
 	for _, option := range options {
 		option(s)

--- a/net/rpc/server_test.go
+++ b/net/rpc/server_test.go
@@ -148,8 +148,8 @@ func startNewServer() {
 	httpOnce.Do(startHttpServer)
 }
 
-func startNewServerWithInterceptor(interceptor ServerInterceptor) {
-	newServer = NewServerWithOpts(WithServerInterceptor(interceptor))
+func startNewServerWithInterceptor(interceptor ServerServiceCallInterceptor) {
+	newServer = NewServerWithOpts(WithServerServiceCallInterceptor(interceptor))
 
 	newServer.Register(new(Arith))
 	newServer.Register(new(Embed))
@@ -471,7 +471,7 @@ func TestServeRequest(t *testing.T) {
 
 func TestServeRequestWithInterceptor(t *testing.T) {
 	a := 1
-	interceptor := ServerInterceptor(func(serviceMethod string, argv, replyv reflect.Value, handler func()) {
+	interceptor := ServerServiceCallInterceptor(func(serviceMethod string, argv, replyv reflect.Value, handler func()) {
 		a = 2
 		handler()
 	})

--- a/net/rpc/server_test.go
+++ b/net/rpc/server_test.go
@@ -510,11 +510,11 @@ func TestServeRequestWithInterceptor(t *testing.T) {
 
 	testServeRequest(t, newServer)
 
-	if  beforeHandler != 2 {
+	if beforeHandler != 2 {
 		t.Errorf("expected beforeHandler value to be 2. Was %d", beforeHandler)
 	}
 
-	if  afterHandler != 4 {
+	if afterHandler != 4 {
 		t.Errorf("expected beforeHandler value to be 4. Was %d", afterHandler)
 	}
 }


### PR DESCRIPTION
### Overview

This is a first pass at adding some middleware support for interceptors. And it's heavily inspired by Daniel's original poc!

On the Consul side, we can start hooking into the exported `ServerInterceptor`.

### Semantics

For the semantics here, I went w a function type to resemble some of the gRPC middleware support.

This is different from the [poc](https://github.com/hashicorp/go-msgpack/compare/91a94c4...hashicorp:dnephin/fork-net-rpc) but can definitely consider switching to an interface type later if that makes more sense.

### Testing
There is a simple test to check that the interceptor code is executed. I also added this to `consul` for a sanity e2e check.

### Reviewer Notes

* Notice that `ServeCodec()` does not actually wire up the interceptor. This is by design for now. I want us to only touch the places that we are going to use in Consul


Co-Authored-By: Daniel Nephin <dnephin@hashicorp.com>

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>