### PR TITLE
net/rpc: remove functions not used by Consul

### DIFF
--- a/go-msgpack/codec/codecs_test.go
+++ b/go-msgpack/codec/codecs_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/gob"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math"
 	"net"
@@ -781,8 +782,13 @@ func doTestRpcOne(t *testing.T, rr Rpc, h Handle, doRequest bool, exitSleepMs ti
 				return // exit serverFn goroutine
 			}
 			if err1 == nil {
-				var sc rpc.ServerCodec = rr.ServerCodec(conn1, h)
-				srv.ServeCodec(sc)
+				var sc = rr.ServerCodec(conn1, h)
+				for {
+					if err := srv.ServeRequest(sc); err == io.EOF {
+						sc.Close()
+						break
+					}
+				}
 			}
 		}
 	}

--- a/net-rpc-msgpackrpc/msgpackrpc.go
+++ b/net-rpc-msgpackrpc/msgpackrpc.go
@@ -34,10 +34,3 @@ func NewClientCodec(conn io.ReadWriteCloser) rpc.ClientCodec {
 func NewServerCodec(conn io.ReadWriteCloser) rpc.ServerCodec {
 	return NewCodec(true, true, conn)
 }
-
-// ServeConn runs the MessagePack-RPC server on a single connection. ServeConn
-// blocks, serving the connection until the client hangs up. The caller
-// typically invokes ServeConn in a go statement.
-func ServeConn(conn io.ReadWriteCloser) {
-	rpc.ServeCodec(NewServerCodec(conn))
-}

--- a/net/rpc/client_test.go
+++ b/net/rpc/client_test.go
@@ -52,6 +52,8 @@ func (s *S) Recv(nul *struct{}, reply *R) error {
 }
 
 func TestGobError(t *testing.T) {
+	srv := NewServer()
+
 	defer func() {
 		err := recover()
 		if err == nil {
@@ -61,13 +63,13 @@ func TestGobError(t *testing.T) {
 			t.Fatal("expected `reading body EOF', got", err)
 		}
 	}()
-	Register(new(S))
+	srv.Register(new(S))
 
 	listen, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
 	}
-	go Accept(listen)
+	go srv.Accept(listen)
 
 	client, err := Dial("tcp", listen.Addr().String())
 	if err != nil {

--- a/net/rpc/client_test.go
+++ b/net/rpc/client_test.go
@@ -69,7 +69,7 @@ func TestGobError(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	go srv.Accept(listen)
+	go accept(srv, listen)
 
 	client, err := Dial("tcp", listen.Addr().String())
 	if err != nil {

--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -133,7 +133,6 @@ import (
 	"go/token"
 	"io"
 	"log"
-	"net/http"
 	"reflect"
 	"strings"
 	"sync"
@@ -431,34 +430,6 @@ func (c *gobServerCodec) Close() error {
 	return c.rwc.Close()
 }
 
-// ServeConn runs the server on a single connection.
-// ServeConn blocks, serving the connection until the client hangs up.
-// The caller typically invokes ServeConn in a go statement.
-// ServeConn uses the gob wire format (see package gob) on the
-// connection. To use an alternate codec, use ServeCodec.
-// See NewClient's comment for information about concurrent access.
-func (server *Server) ServeConn(conn io.ReadWriteCloser) {
-	buf := bufio.NewWriter(conn)
-	srv := &gobServerCodec{
-		rwc:    conn,
-		dec:    gob.NewDecoder(conn),
-		enc:    gob.NewEncoder(buf),
-		encBuf: buf,
-	}
-	server.ServeCodec(srv)
-}
-
-// ServeCodec is like ServeConn but uses the specified codec to
-// decode requests and encode responses.
-func (server *Server) ServeCodec(codec ServerCodec) {
-	defer codec.Close()
-	for {
-		if err := server.ServeRequest(codec); err == io.EOF {
-			return
-		}
-	}
-}
-
 // ServeRequest is like ServeCodec but synchronously serves a single request.
 // It does not close the codec upon completion.
 func (server *Server) ServeRequest(codec ServerCodec) error {
@@ -615,28 +586,3 @@ type ServerCodec interface {
 
 // Can connect to RPC service using HTTP CONNECT to rpcPath.
 var connected = "200 Connected to Go RPC"
-
-// ServeHTTP implements an http.Handler that answers RPC requests.
-func (server *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if req.Method != "CONNECT" {
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		io.WriteString(w, "405 must CONNECT\n")
-		return
-	}
-	conn, _, err := w.(http.Hijacker).Hijack()
-	if err != nil {
-		log.Print("rpc hijacking ", req.RemoteAddr, ": ", err.Error())
-		return
-	}
-	io.WriteString(conn, "HTTP/1.0 "+connected+"\n\n")
-	server.ServeConn(conn)
-}
-
-// HandleHTTP registers an HTTP handler for RPC messages on rpcPath,
-// and a debugging handler on debugPath.
-// It is still necessary to invoke http.Serve(), typically in a go statement.
-func (server *Server) HandleHTTP(rpcPath, debugPath string) {
-	http.Handle(rpcPath, server)
-	http.Handle(debugPath, debugHTTP{server})
-}

--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -133,7 +133,6 @@ import (
 	"go/token"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"reflect"
 	"strings"
@@ -614,21 +613,6 @@ func (server *Server) readRequestHeader(codec ServerCodec) (svc *service, mtype 
 		err = errors.New("rpc: can't find method " + req.ServiceMethod)
 	}
 	return
-}
-
-// Accept accepts connections on the listener and serves requests
-// for each incoming connection. Accept blocks until the listener
-// returns a non-nil error. The caller typically invokes Accept in a
-// go statement.
-func (server *Server) Accept(lis net.Listener) {
-	for {
-		conn, err := lis.Accept()
-		if err != nil {
-			log.Print("rpc.Serve: accept:", err.Error())
-			return
-		}
-		go server.ServeConn(conn)
-	}
 }
 
 // A ServerCodec implements reading of RPC requests and writing of

--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -631,15 +631,6 @@ func (server *Server) Accept(lis net.Listener) {
 	}
 }
 
-// Register publishes the receiver's methods in the DefaultServer.
-func Register(rcvr interface{}) error { return DefaultServer.Register(rcvr) }
-
-// RegisterName is like Register but uses the provided name for the type
-// instead of the receiver's concrete type.
-func RegisterName(name string, rcvr interface{}) error {
-	return DefaultServer.RegisterName(name, rcvr)
-}
-
 // A ServerCodec implements reading of RPC requests and writing of
 // RPC responses for the server side of an RPC session.
 // The server calls ReadRequestHeader and ReadRequestBody in pairs
@@ -656,33 +647,6 @@ type ServerCodec interface {
 	// Close can be called multiple times and must be idempotent.
 	Close() error
 }
-
-// ServeConn runs the DefaultServer on a single connection.
-// ServeConn blocks, serving the connection until the client hangs up.
-// The caller typically invokes ServeConn in a go statement.
-// ServeConn uses the gob wire format (see package gob) on the
-// connection. To use an alternate codec, use ServeCodec.
-// See NewClient's comment for information about concurrent access.
-func ServeConn(conn io.ReadWriteCloser) {
-	DefaultServer.ServeConn(conn)
-}
-
-// ServeCodec is like ServeConn but uses the specified codec to
-// decode requests and encode responses.
-func ServeCodec(codec ServerCodec) {
-	DefaultServer.ServeCodec(codec)
-}
-
-// ServeRequest is like ServeCodec but synchronously serves a single request.
-// It does not close the codec upon completion.
-func ServeRequest(codec ServerCodec) error {
-	return DefaultServer.ServeRequest(codec)
-}
-
-// Accept accepts connections on the listener and serves requests
-// to DefaultServer for each incoming connection.
-// Accept blocks; the caller typically invokes it in a go statement.
-func Accept(lis net.Listener) { DefaultServer.Accept(lis) }
 
 // Can connect to RPC service using HTTP CONNECT to rpcPath.
 var connected = "200 Connected to Go RPC"
@@ -710,11 +674,4 @@ func (server *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (server *Server) HandleHTTP(rpcPath, debugPath string) {
 	http.Handle(rpcPath, server)
 	http.Handle(debugPath, debugHTTP{server})
-}
-
-// HandleHTTP registers an HTTP handler for RPC messages to DefaultServer
-// on DefaultRPCPath and a debugging handler on DefaultDebugPath.
-// It is still necessary to invoke http.Serve(), typically in a go statement.
-func HandleHTTP() {
-	DefaultServer.HandleHTTP(DefaultRPCPath, DefaultDebugPath)
 }


### PR DESCRIPTION
This PR is an attempt to reduce both the production code and exported interface of the `net/rpc` package. Consul only uses `ServeRequest`, and we'd like to only have to instrument that one call. If we can remove the other calls then we reduce the testing we need to perform, and it should make it easier for us to make changes to this fork without spending time on code paths that will not be used. For example, we are adding an interceptor in #8, but it only applies to `ServeRequest` (not `ServeCodec`, which is used by `ServeConn` as well). By removing these methods we remove the risk that those are called with the expectation that the interceptor is called.

I split up this change into a few commits to isolate and document some each step. The commit messages have some details, but I'll add some comments inline as well.
