### PR TITLE
net/rpc: remove a couple args from the ServeRequest flow

### DIFF
--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -363,10 +363,7 @@ func (m *methodType) NumCalls() (n uint) {
 	return n
 }
 
-func (s *service) call(server *Server, sending *sync.Mutex, wg *sync.WaitGroup, mtype *methodType, req *Request, argv, replyv reflect.Value, codec ServerCodec) {
-	if wg != nil {
-		defer wg.Done()
-	}
+func (s *service) call(server *Server, sending *sync.Mutex, mtype *methodType, req *Request, argv, replyv reflect.Value, codec ServerCodec) {
 	mtype.Lock()
 	mtype.numCalls++
 	mtype.Unlock()
@@ -446,7 +443,7 @@ func (server *Server) ServeRequest(codec ServerCodec) error {
 		}
 		return err
 	}
-	service.call(server, sending, nil, mtype, req, argv, replyv, codec)
+	service.call(server, sending, mtype, req, argv, replyv, codec)
 	return nil
 }
 


### PR DESCRIPTION
Branched from #9, so that should be merged first.

This is actually modifying functions used by Consul, so I kept it separate from #9. These two args (one in each commit) should no longer be necessary. The rational for removing each is in the commit messages.