### PR TITLE
add golangci lint on net rpc fork

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,20 @@
+name: golangci-lint
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: golangci-lint-net-rpc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.2.3
+          working-directory: ./net/rpc
+          args: --issues-exit-code=0
+          skip-pkg-cache: true
+          skip-build-cache: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,8 +24,7 @@ jobs:
             --enable ineffassign \
             --enable staticcheck \
             --enable unparam \
-            --rnable unconvert \
+            --enable unconvert \
             --verbose
           skip-pkg-cache: true
           skip-build-cache: true
-          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,6 +15,17 @@ jobs:
         with:
           version: v1.28.3
           working-directory: ./net/rpc
-          args: --issues-exit-code=0
+          args: |
+            --disable-all \
+            --timeout 10m \
+            --enable gofmt \
+            --enable gosimple \
+            --enable govet \
+            --enable ineffassign \
+            --enable staticcheck \
+            --enable unparam \
+            --rnable unconvert \
+            --verbose
           skip-pkg-cache: true
           skip-build-cache: true
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.2.3
+          version: v1.28.3
           working-directory: ./net/rpc
           args: --issues-exit-code=0
           skip-pkg-cache: true


### PR DESCRIPTION
### Overview

Add golangci linter as a GH action over the net rpc fork.

### FAQ

* Why lint over just net rpc fork? 
> We can consider adding linter for other subtrees once the upstream changes.

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>