### PR TITLE
fix: interceptor test uses the refactored accept func

### DIFF
--- a/net/rpc/server_test.go
+++ b/net/rpc/server_test.go
@@ -162,7 +162,7 @@ func startNewServerWithInterceptor(interceptor ServerServiceCallInterceptor) {
 	var l net.Listener
 	l, newServerAddr = listenTCP()
 	log.Println("NewServer test RPC server listening on", newServerAddr)
-	go newServer.Accept(l)
+	go accept(newServer, l)
 }
 
 func startHttpServer() {


### PR DESCRIPTION
### Overview

I think #8 and #9 raced. This fixes the interceptor test to use the refactored func.

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>