### PR TITLE
Allow the interceptor to receive service.call errors

### DIFF
--- a/net/rpc/server_test.go
+++ b/net/rpc/server_test.go
@@ -469,7 +469,7 @@ func TestServeRequestWithInterceptor(t *testing.T) {
 	beforeHandler := 1
 	afterHandler := 3
 
-	interceptor := ServerServiceCallInterceptor(func(reqServiceMethod string, argv, replyv reflect.Value, handler func()) {
+	interceptor := ServerServiceCallInterceptor(func(reqServiceMethod string, argv, replyv reflect.Value, handler func() error) {
 		// we will assert on this value later
 		beforeHandler = 2
 
@@ -490,7 +490,7 @@ func TestServeRequestWithInterceptor(t *testing.T) {
 		}
 
 		// let the RPC req happen
-		handler()
+		_ = handler()
 
 		actualReply := replyv.Elem().Interface().(Reply)
 		if actualReply.C != 15 {
@@ -499,7 +499,6 @@ func TestServeRequestWithInterceptor(t *testing.T) {
 
 		// we will assert on this value later
 		afterHandler = 4
-
 	})
 
 	startNewServerWithInterceptor(interceptor)
@@ -532,6 +531,29 @@ func testServeRequest(t *testing.T, server *Server) {
 	err = client.Call("Arith.Add", nil, reply)
 	if err == nil {
 		t.Errorf("expected error calling Arith.Add with nil arg")
+	}
+}
+
+func TestServeRequestWithInterceptor_ServiceCallError(t *testing.T) {
+	var handlerError error
+
+	interceptor := ServerServiceCallInterceptor(func(reqServiceMethod string, argv, replyv reflect.Value, handler func() error) {
+		handlerError = handler()
+	})
+
+	startNewServerWithInterceptor(interceptor)
+
+	client := CodecEmulator{server: newServer}
+	defer client.Close()
+
+	args := &Args{A: 7, B: 0}
+	reply := new(Reply)
+	// ignore this error, because this is not how a real client reports these errors
+	_ = client.Call("Arith.Div", args, reply)
+
+	expected := "divide by zero"
+	if handlerError == nil || handlerError.Error() != expected {
+		t.Fatalf("expected error %v, got %v", expected, handlerError)
 	}
 }
 

--- a/net/rpc/server_test.go
+++ b/net/rpc/server_test.go
@@ -490,7 +490,10 @@ func TestServeRequestWithInterceptor(t *testing.T) {
 		}
 
 		// let the RPC req happen
-		_ = handler()
+		err := handler()
+		if err != nil {
+			t.Errorf("expected handler err to be nil. Was %s", err)
+		}
 
 		actualReply := replyv.Elem().Interface().(Reply)
 		if actualReply.C != 15 {


### PR DESCRIPTION
Previously these were not exposed to the interceptor. The error was handled in `service.call`, but we need it in `ServeRequest` so that we can pass it to the interceptor. 

This PR changes `service.call` to return the error.

Passing in a string for the error was going to require additional logic, so instead I changed `sendResponse` to accept an error, which makes it easier to pass in `err` and check for the `nil` in `sendResponse`.
