### PR TITLE
Add interceptor before body is parsed for rate limiting purposes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: docker.mirror.hashicorp.services/cimg/go:1.17
+      - image: docker.mirror.hashicorp.services/cimg/go:1.19
     steps:
       - checkout
       - run: go mod download

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+test: ## Run tests.
+	go test ./...

--- a/go-msgpack/codec/msgpack.go
+++ b/go-msgpack/codec/msgpack.go
@@ -10,11 +10,12 @@ without caring about the type.
 
 For compatibility with behaviour of msgpack-c reference implementation:
   - Go intX (>0) and uintX
-    IS ENCODED AS
+       IS ENCODED AS
     msgpack +ve fixnum, unsigned
   - Go intX (<0)
-    IS ENCODED AS
+       IS ENCODED AS
     msgpack -ve fixnum, signed
+
 */
 package codec
 
@@ -668,7 +669,7 @@ func (d *msgpackDecDriver) decodeExt(verifyTag bool, tag byte) (xtag byte, xbs [
 
 //--------------------------------------------------
 
-// MsgpackHandle is a Handle for the Msgpack Schema-Free Encoding Format.
+//MsgpackHandle is a Handle for the Msgpack Schema-Free Encoding Format.
 type MsgpackHandle struct {
 	BasicHandle
 

--- a/go-msgpack/codec/msgpack.go
+++ b/go-msgpack/codec/msgpack.go
@@ -10,12 +10,11 @@ without caring about the type.
 
 For compatibility with behaviour of msgpack-c reference implementation:
   - Go intX (>0) and uintX
-       IS ENCODED AS
+    IS ENCODED AS
     msgpack +ve fixnum, unsigned
   - Go intX (<0)
-       IS ENCODED AS
+    IS ENCODED AS
     msgpack -ve fixnum, signed
-
 */
 package codec
 
@@ -669,7 +668,7 @@ func (d *msgpackDecDriver) decodeExt(verifyTag bool, tag byte) (xtag byte, xbs [
 
 //--------------------------------------------------
 
-//MsgpackHandle is a Handle for the Msgpack Schema-Free Encoding Format.
+// MsgpackHandle is a Handle for the Msgpack Schema-Free Encoding Format.
 type MsgpackHandle struct {
 	BasicHandle
 
@@ -742,6 +741,7 @@ func (c *msgpackSpecRpcCodec) ReadResponseHeader(r *rpc.Response) error {
 }
 
 func (c *msgpackSpecRpcCodec) ReadRequestHeader(r *rpc.Request) error {
+	r.SourceAddr = c.conn.RemoteAddr()
 	return c.parseCustomHeader(0, &r.Seq, &r.ServiceMethod)
 }
 
@@ -805,11 +805,11 @@ type msgpackSpecRpc struct{}
 // Its methods (ServerCodec and ClientCodec) return values that implement RpcCodecBuffered.
 var MsgpackSpecRpc msgpackSpecRpc
 
-func (x msgpackSpecRpc) ServerCodec(conn io.ReadWriteCloser, h Handle) rpc.ServerCodec {
+func (x msgpackSpecRpc) ServerCodec(conn Conn, h Handle) rpc.ServerCodec {
 	return &msgpackSpecRpcCodec{newRPCCodec(conn, h)}
 }
 
-func (x msgpackSpecRpc) ClientCodec(conn io.ReadWriteCloser, h Handle) rpc.ClientCodec {
+func (x msgpackSpecRpc) ClientCodec(conn Conn, h Handle) rpc.ClientCodec {
 	return &msgpackSpecRpcCodec{newRPCCodec(conn, h)}
 }
 

--- a/go-msgpack/codec/msgpack.go
+++ b/go-msgpack/codec/msgpack.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 )
@@ -742,7 +743,6 @@ func (c *msgpackSpecRpcCodec) ReadResponseHeader(r *rpc.Response) error {
 }
 
 func (c *msgpackSpecRpcCodec) ReadRequestHeader(r *rpc.Request) error {
-	r.SourceAddr = c.conn.RemoteAddr()
 	return c.parseCustomHeader(0, &r.Seq, &r.ServiceMethod)
 }
 
@@ -752,6 +752,10 @@ func (c *msgpackSpecRpcCodec) ReadRequestBody(body interface{}) error {
 	}
 	bodyArr := []interface{}{body}
 	return c.read(&bodyArr)
+}
+
+func (c *msgpackSpecRpcCodec) SourceAddr() net.Addr {
+	return c.conn.RemoteAddr()
 }
 
 func (c *msgpackSpecRpcCodec) parseCustomHeader(expectTypeByte byte, msgid *uint64, methodOrError *string) (err error) {

--- a/go-msgpack/codec/rpc.go
+++ b/go-msgpack/codec/rpc.go
@@ -131,12 +131,15 @@ func (c *goRpcCodec) ReadResponseHeader(r *rpc.Response) error {
 }
 
 func (c *goRpcCodec) ReadRequestHeader(r *rpc.Request) error {
-	r.SourceAddr = c.conn.RemoteAddr()
 	return c.read(r)
 }
 
 func (c *goRpcCodec) ReadRequestBody(body interface{}) error {
 	return c.read(body)
+}
+
+func (c *goRpcCodec) SourceAddr() net.Addr {
+	return c.conn.RemoteAddr()
 }
 
 // -------------------------------------

--- a/go-msgpack/codec/rpc.go
+++ b/go-msgpack/codec/rpc.go
@@ -6,6 +6,7 @@ package codec
 import (
 	"bufio"
 	"io"
+	"net"
 	"sync"
 
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
@@ -13,8 +14,8 @@ import (
 
 // Rpc provides a rpc Server or Client Codec for rpc communication.
 type Rpc interface {
-	ServerCodec(conn io.ReadWriteCloser, h Handle) rpc.ServerCodec
-	ClientCodec(conn io.ReadWriteCloser, h Handle) rpc.ClientCodec
+	ServerCodec(conn Conn, h Handle) rpc.ServerCodec
+	ClientCodec(conn Conn, h Handle) rpc.ClientCodec
 }
 
 // RpcCodecBuffered allows access to the underlying bufio.Reader/Writer
@@ -28,26 +29,31 @@ type RpcCodecBuffered interface {
 
 // -------------------------------------
 
-// rpcCodec defines the struct members and common methods.
-type rpcCodec struct {
-	rwc io.ReadWriteCloser
-	dec *Decoder
-	enc *Encoder
-	bw  *bufio.Writer
-	br  *bufio.Reader
-	mu  sync.Mutex
-	cls bool
+type Conn interface {
+	io.ReadWriteCloser
+	RemoteAddr() net.Addr
 }
 
-func newRPCCodec(conn io.ReadWriteCloser, h Handle) rpcCodec {
+// rpcCodec defines the struct members and common methods.
+type rpcCodec struct {
+	conn Conn
+	dec  *Decoder
+	enc  *Encoder
+	bw   *bufio.Writer
+	br   *bufio.Reader
+	mu   sync.Mutex
+	cls  bool
+}
+
+func newRPCCodec(conn Conn, h Handle) rpcCodec {
 	bw := bufio.NewWriter(conn)
 	br := bufio.NewReader(conn)
 	return rpcCodec{
-		rwc: conn,
-		bw:  bw,
-		br:  br,
-		enc: NewEncoder(bw, h),
-		dec: NewDecoder(br, h),
+		conn: conn,
+		bw:   bw,
+		br:   br,
+		enc:  NewEncoder(bw, h),
+		dec:  NewDecoder(br, h),
 	}
 }
 
@@ -94,7 +100,7 @@ func (c *rpcCodec) Close() error {
 		return io.EOF
 	}
 	c.cls = true
-	return c.rwc.Close()
+	return c.conn.Close()
 }
 
 func (c *rpcCodec) ReadResponseBody(body interface{}) error {
@@ -125,6 +131,7 @@ func (c *goRpcCodec) ReadResponseHeader(r *rpc.Response) error {
 }
 
 func (c *goRpcCodec) ReadRequestHeader(r *rpc.Request) error {
+	r.SourceAddr = c.conn.RemoteAddr()
 	return c.read(r)
 }
 
@@ -142,11 +149,11 @@ type goRpc struct{}
 // Its methods (ServerCodec and ClientCodec) return values that implement RpcCodecBuffered.
 var GoRpc goRpc
 
-func (x goRpc) ServerCodec(conn io.ReadWriteCloser, h Handle) rpc.ServerCodec {
+func (x goRpc) ServerCodec(conn Conn, h Handle) rpc.ServerCodec {
 	return &goRpcCodec{newRPCCodec(conn, h)}
 }
 
-func (x goRpc) ClientCodec(conn io.ReadWriteCloser, h Handle) rpc.ClientCodec {
+func (x goRpc) ClientCodec(conn Conn, h Handle) rpc.ClientCodec {
 	return &goRpcCodec{newRPCCodec(conn, h)}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul-net-rpc
 
-go 1.17
+go 1.19
 
 require github.com/hashicorp/go-multierror v1.1.1
 

--- a/net-rpc-msgpackrpc/codec.go
+++ b/net-rpc-msgpackrpc/codec.go
@@ -58,7 +58,6 @@ func NewCodecFromHandle(bufReads, bufWrites bool, conn net.Conn,
 }
 
 func (cc *MsgpackCodec) ReadRequestHeader(r *rpc.Request) error {
-	r.SourceAddr = cc.conn.RemoteAddr()
 	return cc.read(r)
 }
 
@@ -84,6 +83,10 @@ func (cc *MsgpackCodec) WriteRequest(r *rpc.Request, body interface{}) error {
 	cc.writeLock.Lock()
 	defer cc.writeLock.Unlock()
 	return cc.write(r, body)
+}
+
+func (cc *MsgpackCodec) SourceAddr() net.Addr {
+	return cc.conn.RemoteAddr()
 }
 
 func (cc *MsgpackCodec) Close() error {

--- a/net-rpc-msgpackrpc/codec.go
+++ b/net-rpc-msgpackrpc/codec.go
@@ -3,6 +3,7 @@ package msgpackrpc
 import (
 	"bufio"
 	"io"
+	"net"
 	"sync"
 
 	"github.com/hashicorp/consul-net-rpc/go-msgpack/codec"
@@ -18,7 +19,7 @@ var (
 // using the msgpack encoding
 type MsgpackCodec struct {
 	closed    bool
-	conn      io.ReadWriteCloser
+	conn      net.Conn
 	bufR      *bufio.Reader
 	bufW      *bufio.Writer
 	enc       *codec.Encoder
@@ -29,14 +30,14 @@ type MsgpackCodec struct {
 // NewCodec returns a MsgpackCodec that can be used as either a Client or Server
 // rpc Codec using a default handle. It also provides controls for enabling and
 // disabling buffering for both reads and writes.
-func NewCodec(bufReads, bufWrites bool, conn io.ReadWriteCloser) *MsgpackCodec {
+func NewCodec(bufReads, bufWrites bool, conn net.Conn) *MsgpackCodec {
 	return NewCodecFromHandle(bufReads, bufWrites, conn, msgpackHandle)
 }
 
 // NewCodecFromHandle returns a MsgpackCodec that can be used as either a Client
 // or Server rpc Codec using the passed handle. It also provides controls for
 // enabling and disabling buffering for both reads and writes.
-func NewCodecFromHandle(bufReads, bufWrites bool, conn io.ReadWriteCloser,
+func NewCodecFromHandle(bufReads, bufWrites bool, conn net.Conn,
 	h *codec.MsgpackHandle) *MsgpackCodec {
 	cc := &MsgpackCodec{
 		conn: conn,
@@ -57,6 +58,7 @@ func NewCodecFromHandle(bufReads, bufWrites bool, conn io.ReadWriteCloser,
 }
 
 func (cc *MsgpackCodec) ReadRequestHeader(r *rpc.Request) error {
+	r.SourceAddr = cc.conn.RemoteAddr()
 	return cc.read(r)
 }
 

--- a/net-rpc-msgpackrpc/msgpackrpc.go
+++ b/net-rpc-msgpackrpc/msgpackrpc.go
@@ -4,7 +4,6 @@
 package msgpackrpc
 
 import (
-	"io"
 	"net"
 
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
@@ -21,16 +20,16 @@ func Dial(network, address string) (*rpc.Client, error) {
 
 // NewClient returns a new rpc.Client to handle requests to the set of
 // services at the other end of the connection.
-func NewClient(conn io.ReadWriteCloser) *rpc.Client {
+func NewClient(conn net.Conn) *rpc.Client {
 	return rpc.NewClientWithCodec(NewClientCodec(conn))
 }
 
 // NewClientCodec returns a new rpc.ClientCodec using MessagePack-RPC on conn.
-func NewClientCodec(conn io.ReadWriteCloser) rpc.ClientCodec {
+func NewClientCodec(conn net.Conn) rpc.ClientCodec {
 	return NewCodec(true, true, conn)
 }
 
 // NewServerCodec returns a new rpc.ServerCodec using MessagePack-RPC on conn.
-func NewServerCodec(conn io.ReadWriteCloser) rpc.ServerCodec {
+func NewServerCodec(conn net.Conn) rpc.ServerCodec {
 	return NewCodec(true, true, conn)
 }

--- a/net/rpc/client_test.go
+++ b/net/rpc/client_test.go
@@ -59,7 +59,7 @@ func TestGobError(t *testing.T) {
 		if err == nil {
 			t.Fatal("no error")
 		}
-		if !strings.Contains(err.(error).Error(), "reading body EOF") {
+		if !strings.Contains(err.(error).Error(), "reading body unexpected EOF") {
 			t.Fatal("expected `reading body EOF', got", err)
 		}
 	}()

--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -3,126 +3,126 @@
 // license that can be found in the LICENSE file.
 
 /*
-Package rpc provides access to the exported methods of an object across a
-network or other I/O connection.  A server registers an object, making it visible
-as a service with the name of the type of the object.  After registration, exported
-methods of the object will be accessible remotely.  A server may register multiple
-objects (services) of different types but it is an error to register multiple
-objects of the same type.
+	Package rpc provides access to the exported methods of an object across a
+	network or other I/O connection.  A server registers an object, making it visible
+	as a service with the name of the type of the object.  After registration, exported
+	methods of the object will be accessible remotely.  A server may register multiple
+	objects (services) of different types but it is an error to register multiple
+	objects of the same type.
 
-Only methods that satisfy these criteria will be made available for remote access;
-other methods will be ignored:
+	Only methods that satisfy these criteria will be made available for remote access;
+	other methods will be ignored:
 
-  - the method's type is exported.
-  - the method is exported.
-  - the method has two arguments, both exported (or builtin) types.
-  - the method's second argument is a pointer.
-  - the method has return type error.
+		- the method's type is exported.
+		- the method is exported.
+		- the method has two arguments, both exported (or builtin) types.
+		- the method's second argument is a pointer.
+		- the method has return type error.
 
-In effect, the method must look schematically like
+	In effect, the method must look schematically like
 
-	func (t *T) MethodName(argType T1, replyType *T2) error
+		func (t *T) MethodName(argType T1, replyType *T2) error
 
-where T1 and T2 can be marshaled by encoding/gob.
-These requirements apply even if a different codec is used.
-(In the future, these requirements may soften for custom codecs.)
+	where T1 and T2 can be marshaled by encoding/gob.
+	These requirements apply even if a different codec is used.
+	(In the future, these requirements may soften for custom codecs.)
 
-The method's first argument represents the arguments provided by the caller; the
-second argument represents the result parameters to be returned to the caller.
-The method's return value, if non-nil, is passed back as a string that the client
-sees as if created by errors.New.  If an error is returned, the reply parameter
-will not be sent back to the client.
+	The method's first argument represents the arguments provided by the caller; the
+	second argument represents the result parameters to be returned to the caller.
+	The method's return value, if non-nil, is passed back as a string that the client
+	sees as if created by errors.New.  If an error is returned, the reply parameter
+	will not be sent back to the client.
 
-The server may handle requests on a single connection by calling ServeConn.  More
-typically it will create a network listener and call Accept or, for an HTTP
-listener, HandleHTTP and http.Serve.
+	The server may handle requests on a single connection by calling ServeConn.  More
+	typically it will create a network listener and call Accept or, for an HTTP
+	listener, HandleHTTP and http.Serve.
 
-A client wishing to use the service establishes a connection and then invokes
-NewClient on the connection.  The convenience function Dial (DialHTTP) performs
-both steps for a raw network connection (an HTTP connection).  The resulting
-Client object has two methods, Call and Go, that specify the service and method to
-call, a pointer containing the arguments, and a pointer to receive the result
-parameters.
+	A client wishing to use the service establishes a connection and then invokes
+	NewClient on the connection.  The convenience function Dial (DialHTTP) performs
+	both steps for a raw network connection (an HTTP connection).  The resulting
+	Client object has two methods, Call and Go, that specify the service and method to
+	call, a pointer containing the arguments, and a pointer to receive the result
+	parameters.
 
-The Call method waits for the remote call to complete while the Go method
-launches the call asynchronously and signals completion using the Call
-structure's Done channel.
+	The Call method waits for the remote call to complete while the Go method
+	launches the call asynchronously and signals completion using the Call
+	structure's Done channel.
 
-Unless an explicit codec is set up, package encoding/gob is used to
-transport the data.
+	Unless an explicit codec is set up, package encoding/gob is used to
+	transport the data.
 
-Here is a simple example.  A server wishes to export an object of type Arith:
+	Here is a simple example.  A server wishes to export an object of type Arith:
 
-	package server
+		package server
 
-	import "errors"
+		import "errors"
 
-	type Args struct {
-		A, B int
-	}
-
-	type Quotient struct {
-		Quo, Rem int
-	}
-
-	type Arith int
-
-	func (t *Arith) Multiply(args *Args, reply *int) error {
-		*reply = args.A * args.B
-		return nil
-	}
-
-	func (t *Arith) Divide(args *Args, quo *Quotient) error {
-		if args.B == 0 {
-			return errors.New("divide by zero")
+		type Args struct {
+			A, B int
 		}
-		quo.Quo = args.A / args.B
-		quo.Rem = args.A % args.B
-		return nil
-	}
 
-The server calls (for HTTP service):
+		type Quotient struct {
+			Quo, Rem int
+		}
 
-	arith := new(Arith)
-	rpc.Register(arith)
-	rpc.HandleHTTP()
-	l, e := net.Listen("tcp", ":1234")
-	if e != nil {
-		log.Fatal("listen error:", e)
-	}
-	go http.Serve(l, nil)
+		type Arith int
 
-At this point, clients can see a service "Arith" with methods "Arith.Multiply" and
-"Arith.Divide".  To invoke one, a client first dials the server:
+		func (t *Arith) Multiply(args *Args, reply *int) error {
+			*reply = args.A * args.B
+			return nil
+		}
 
-	client, err := rpc.DialHTTP("tcp", serverAddress + ":1234")
-	if err != nil {
-		log.Fatal("dialing:", err)
-	}
+		func (t *Arith) Divide(args *Args, quo *Quotient) error {
+			if args.B == 0 {
+				return errors.New("divide by zero")
+			}
+			quo.Quo = args.A / args.B
+			quo.Rem = args.A % args.B
+			return nil
+		}
 
-Then it can make a remote call:
+	The server calls (for HTTP service):
 
-	// Synchronous call
-	args := &server.Args{7,8}
-	var reply int
-	err = client.Call("Arith.Multiply", args, &reply)
-	if err != nil {
-		log.Fatal("arith error:", err)
-	}
-	fmt.Printf("Arith: %d*%d=%d", args.A, args.B, reply)
+		arith := new(Arith)
+		rpc.Register(arith)
+		rpc.HandleHTTP()
+		l, e := net.Listen("tcp", ":1234")
+		if e != nil {
+			log.Fatal("listen error:", e)
+		}
+		go http.Serve(l, nil)
 
-or
+	At this point, clients can see a service "Arith" with methods "Arith.Multiply" and
+	"Arith.Divide".  To invoke one, a client first dials the server:
 
-	// Asynchronous call
-	quotient := new(Quotient)
-	divCall := client.Go("Arith.Divide", args, quotient, nil)
-	replyCall := <-divCall.Done	// will be equal to divCall
-	// check errors, print, etc.
+		client, err := rpc.DialHTTP("tcp", serverAddress + ":1234")
+		if err != nil {
+			log.Fatal("dialing:", err)
+		}
 
-A server implementation will often provide a simple, type-safe wrapper for the
-client.
+	Then it can make a remote call:
 
-The net/rpc package is frozen and is not accepting new features.
+		// Synchronous call
+		args := &server.Args{7,8}
+		var reply int
+		err = client.Call("Arith.Multiply", args, &reply)
+		if err != nil {
+			log.Fatal("arith error:", err)
+		}
+		fmt.Printf("Arith: %d*%d=%d", args.A, args.B, reply)
+
+	or
+
+		// Asynchronous call
+		quotient := new(Quotient)
+		divCall := client.Go("Arith.Divide", args, quotient, nil)
+		replyCall := <-divCall.Done	// will be equal to divCall
+		// check errors, print, etc.
+
+	A server implementation will often provide a simple, type-safe wrapper for the
+	client.
+
+	The net/rpc package is frozen and is not accepting new features.
 */
 package rpc
 
@@ -246,11 +246,10 @@ func isExportedOrBuiltinType(t reflect.Type) bool {
 
 // Register publishes in the server the set of methods of the
 // receiver value that satisfy the following conditions:
-//   - exported method of exported type
-//   - two arguments, both of exported type
-//   - the second argument is a pointer
-//   - one return value, of type error
-//
+//	- exported method of exported type
+//	- two arguments, both of exported type
+//	- the second argument is a pointer
+//	- one return value, of type error
 // It returns an error if the receiver is not an exported type or has
 // no suitable methods. It also logs the error using package log.
 // The client accesses each method using a string of the form "Type.Method",

--- a/net/rpc/server_test.go
+++ b/net/rpc/server_test.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"reflect"
 	"runtime"
 	"strings"
@@ -450,7 +451,7 @@ func (codec *CodecEmulator) Call(serviceMethod string, args *Args, reply *Reply)
 func (codec *CodecEmulator) ReadRequestHeader(req *Request) error {
 	req.ServiceMethod = codec.serviceMethod
 	req.Seq = 0
-	req.SourceAddr = &net.TCPAddr{IP: []byte{99, 99, 99, 99}, Port: 8080, Zone: ""}
+	req.SourceAddr = net.TCPAddrFromAddrPort(netip.MustParseAddrPort("1.2.3.4:8080"))
 	return nil
 }
 
@@ -534,7 +535,7 @@ func TestServeRequestWithInterceptor(t *testing.T) {
 
 func TestPreBodyInterceptor_Success(t *testing.T) {
 	preBodyInterceptorCalled := false
-	expectedSourceAddr := &net.TCPAddr{IP: []byte{99, 99, 99, 99}, Port: 8080, Zone: ""}
+	expectedSourceAddr := net.TCPAddrFromAddrPort(netip.MustParseAddrPort("1.2.3.4:8080"))
 
 	preBodyInterceptor := PreBodyInterceptor(func(reqServiceMethod string, sourceAddr net.Addr) error {
 		if reqServiceMethod != "Arith.Add" {

--- a/net/rpc/server_test.go
+++ b/net/rpc/server_test.go
@@ -151,6 +151,20 @@ func startNewServer() {
 	httpOnce.Do(startHttpServer)
 }
 
+func startNewServerWithPreBodyInterceptor(preBodyinterceptor PreBodyInterceptor) {
+	newServer = NewServerWithOpts(WithPreBodyInterceptor(preBodyinterceptor))
+
+	newServer.Register(new(Arith))
+	newServer.Register(new(Embed))
+	newServer.RegisterName("net.rpc.Arith", new(Arith))
+	newServer.RegisterName("newServer.Arith", new(Arith))
+
+	var l net.Listener
+	l, newServerAddr = listenTCP()
+	log.Println("NewServer test RPC server listening on", newServerAddr)
+	go accept(newServer, l)
+}
+
 func startNewServerWithInterceptor(interceptor ServerServiceCallInterceptor) {
 	newServer = NewServerWithOpts(WithServerServiceCallInterceptor(interceptor))
 
@@ -436,6 +450,7 @@ func (codec *CodecEmulator) Call(serviceMethod string, args *Args, reply *Reply)
 func (codec *CodecEmulator) ReadRequestHeader(req *Request) error {
 	req.ServiceMethod = codec.serviceMethod
 	req.Seq = 0
+	req.SourceAddr = &net.TCPAddr{IP: []byte{99, 99, 99, 99}, Port: 8080, Zone: ""}
 	return nil
 }
 
@@ -514,6 +529,59 @@ func TestServeRequestWithInterceptor(t *testing.T) {
 
 	if afterHandler != 4 {
 		t.Errorf("expected beforeHandler value to be 4. Was %d", afterHandler)
+	}
+}
+
+func TestPreBodyInterceptor_Success(t *testing.T) {
+	preBodyInterceptorCalled := false
+	expectedSourceAddr := &net.TCPAddr{IP: []byte{99, 99, 99, 99}, Port: 8080, Zone: ""}
+
+	preBodyInterceptor := PreBodyInterceptor(func(reqServiceMethod string, sourceAddr net.Addr) error {
+		if reqServiceMethod != "Arith.Add" {
+			t.Errorf("expected reqServiceMethod to be Arith.Add but was %s", reqServiceMethod)
+		}
+
+		if sourceAddr.String() != expectedSourceAddr.String() {
+			t.Errorf("expected sourceAddr to be %s but was %s", expectedSourceAddr, sourceAddr)
+		}
+
+		preBodyInterceptorCalled = true
+		return nil
+	})
+
+	startNewServerWithPreBodyInterceptor(preBodyInterceptor)
+	testServeRequest(t, newServer)
+
+	if !preBodyInterceptorCalled {
+		t.Errorf("expected preBodyInterceptorCalled to be true")
+	}
+}
+
+func TestPreBodyInterceptor_Failure(t *testing.T) {
+	preBodyInterceptorCalled := false
+
+	preBodyInterceptor := PreBodyInterceptor(func(reqServiceMethod string, sourceAddr net.Addr) error {
+		preBodyInterceptorCalled = true
+		return errors.New("request denied")
+	})
+
+	startNewServerWithPreBodyInterceptor(preBodyInterceptor)
+
+	client := CodecEmulator{server: newServer}
+	defer client.Close()
+
+	args := &Args{A: 4, B: 2}
+	reply := new(Reply)
+	// ignore this error, because this is not how a real client reports these errors
+	_ = client.Call("Arith.Div", args, reply)
+
+	if !preBodyInterceptorCalled {
+		t.Errorf("expected preBodyInterceptorCalled to be true")
+	}
+
+	expected := "request denied"
+	if client.err.Error() != expected {
+		t.Errorf("expected client.err to be %q but was %s", expected, client.err.Error())
 	}
 }
 
@@ -965,10 +1033,10 @@ func serveHTTP(server *Server) func(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func serveConn(server *Server, conn io.ReadWriteCloser) {
+func serveConn(server *Server, conn net.Conn) {
 	buf := bufio.NewWriter(conn)
 	codec := &gobServerCodec{
-		rwc:    conn,
+		conn:   conn,
 		dec:    gob.NewDecoder(conn),
 		enc:    gob.NewEncoder(buf),
 		encBuf: buf,

--- a/net/rpc/server_test.go
+++ b/net/rpc/server_test.go
@@ -451,7 +451,6 @@ func (codec *CodecEmulator) Call(serviceMethod string, args *Args, reply *Reply)
 func (codec *CodecEmulator) ReadRequestHeader(req *Request) error {
 	req.ServiceMethod = codec.serviceMethod
 	req.Seq = 0
-	req.SourceAddr = net.TCPAddrFromAddrPort(netip.MustParseAddrPort("1.2.3.4:8080"))
 	return nil
 }
 
@@ -470,6 +469,10 @@ func (codec *CodecEmulator) WriteResponse(resp *Response, reply interface{}) err
 		*codec.reply = *(reply.(*Reply))
 	}
 	return nil
+}
+
+func (codec *CodecEmulator) SourceAddr() net.Addr {
+	return net.TCPAddrFromAddrPort(netip.MustParseAddrPort("1.2.3.4:8080"))
 }
 
 func (codec *CodecEmulator) Close() error {


### PR DESCRIPTION
Testing:
- [x] added preBodyInterceptor unit tests + `make test` is green
- [x] integration test with consul (ran consul unit tests with `go.mod` using local `consul-net-rpc`)

FYI, all white space only changes were not intentional (done by editor).