### PR TITLE
SEC-090: Automated trusted workflow pinning (2023-03-10)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,10 +8,10 @@ jobs:
     name: golangci-lint-net-rpc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:
           version: v1.28.3
           working-directory: ./net/rpc


### PR DESCRIPTION
This PR pins action references in workflow and action files to SHAs.
This is in support of [SEC-090](https://github.com/hashicorp/security-tsccr/issues/214);
Any questions please reach out to [#team-prodsec](https://go.hashi.co/team-prodsec)
