### PR TITLE
net/rpc: expose a way to reflectively invoke an rpc method from the server-side

### DIFF
--- a/net/rpc/server.go
+++ b/net/rpc/server.go
@@ -682,15 +682,17 @@ func (server *Server) InvokeMethod(
 
 	function := mtype.method.Func
 
+	// Capture the error so we can directly return it.
+	var callErr error
 	handler := func() error {
-		return callServiceMethod(ctx, mtype.HasContext, function, svc.rcvr, argv, replyv)
+		callErr = callServiceMethod(ctx, mtype.HasContext, function, svc.rcvr, argv, replyv)
+		return callErr
 	}
 
-	var callErr error
 	if server.serverServiceCallInterceptor != nil {
 		server.serverServiceCallInterceptor(serviceMethod, argv, replyv, handler)
 	} else {
-		callErr = handler()
+		_ = handler()
 	}
 
 	if callErr != nil {

--- a/net/rpc/server_test.go
+++ b/net/rpc/server_test.go
@@ -220,13 +220,22 @@ func TestRPC(t *testing.T) {
 		testRPC(t, newServer, serverAddr, nil)
 		testNewServerRPC(t, serverAddr)
 	})
-	t.Run("separate with interceptor", func(t *testing.T) {
+	t.Run("separate with call interceptor", func(t *testing.T) {
 		var callCount atomic.Int32
 		interceptor := ServerServiceCallInterceptor(func(_ string, _, _ reflect.Value, handler func() error) {
 			callCount.Add(1)
 			_ = handler()
 		})
 		newServer, serverAddr := startNewServerWithInterceptor(t, interceptor)
+		testRPC(t, newServer, serverAddr, &callCount)
+	})
+	t.Run("separate with prebody interceptor", func(t *testing.T) {
+		var callCount atomic.Int32
+		preBodyInterceptor := PreBodyInterceptor(func(reqServiceMethod string, sourceAddr net.Addr) error {
+			callCount.Add(1)
+			return nil
+		})
+		newServer, serverAddr := startNewServerWithPreBodyInterceptor(t, preBodyInterceptor)
 		testRPC(t, newServer, serverAddr, &callCount)
 	})
 }

--- a/net/rpc/server_test.go
+++ b/net/rpc/server_test.go
@@ -320,6 +320,21 @@ func testRPC(t *testing.T, addr string) {
 		t.Errorf("Mul: expected %d got %d", reply.C, args.A*args.B)
 	}
 
+	// invoke directly
+	rawReply, err := DefaultServer.InvokeMethod("Arith.Mul", func(argvPtr any) error {
+		args := argvPtr.(*Args)
+		args.A = 4
+		args.B = 5
+		return nil
+	}, net.TCPAddrFromAddrPort(netip.MustParseAddrPort("1.2.3.4:8080")))
+	if err != nil {
+		t.Errorf("Mul: expected no error but got string %q", err.Error())
+	}
+	reply = rawReply.Interface().(*Reply)
+	if reply.C != 20 {
+		t.Errorf("Mul: expected %d got %d", reply.C, 20)
+	}
+
 	// ServiceName contain "." character
 	args = &Args{7, 8}
 	reply = new(Reply)


### PR DESCRIPTION
This PR extracts a few reflective helpers already used by `net/rpc` dispatch on the servers and uses them to expose a new `InvokeMethod` method to directly call one of the registered methods.

Also allow for RPC methods to optionally begin with a `context.Context` parameter and pass this down from `ServeRequestContext` into invoked methods. Contexts will not be propagated from client to server however.

These new behaviors will not be used in Consul yet, but are being added proactively to allow for experimental use.

**This PR should be reviewed commit-by-commit**