### PR TITLE
Close on WriteResponse errors (pull from upstream)

### DIFF
--- a/net-rpc-msgpackrpc/codec.go
+++ b/net-rpc-msgpackrpc/codec.go
@@ -88,10 +88,6 @@ func (cc *MsgpackCodec) WriteRequest(r *rpc.Request, body interface{}) error {
 	return cc.write(r, body)
 }
 
-func (cc *MsgpackCodec) SourceAddr() net.Addr {
-	return cc.conn.RemoteAddr()
-}
-
 func (cc *MsgpackCodec) Close() error {
 	if cc.closed {
 		return nil
@@ -127,4 +123,8 @@ func (cc *MsgpackCodec) read(obj interface{}) (err error) {
 		return cc.dec.Decode(&obj2)
 	}
 	return cc.dec.Decode(obj)
+}
+
+func (cc *MsgpackCodec) SourceAddr() net.Addr {
+	return cc.conn.RemoteAddr()
 }

--- a/net-rpc-msgpackrpc/codec.go
+++ b/net-rpc-msgpackrpc/codec.go
@@ -68,6 +68,19 @@ func (cc *MsgpackCodec) ReadRequestBody(out interface{}) error {
 	return cc.read(out)
 }
 
+// WriteResponse encodes the provided *rpc.Response header and its associated
+// body, writing both to the underlying connection using Msgpack encoding.
+//
+// If an error occurs at any stage of encoding the header, encoding the body, or
+// flushing the buffered writer (if one is used), the codec will close the
+// underlying connection. This is done because the net/rpc package (which is
+// frozen) does not propagate errors returned by WriteResponse, but optionally
+// logs them. By closing the connection on error, we ensure that the codec (and
+// underlying connection) is not used further in an inconsistent state, and
+// subsequent calls immediately return io.EOF.
+//
+// Note: It is assumed that once an error is encountered, further communication
+// using this codec is unsafe.
 func (cc *MsgpackCodec) WriteResponse(r *rpc.Response, body interface{}) error {
 	cc.writeLock.Lock()
 	defer cc.writeLock.Unlock()
@@ -75,13 +88,18 @@ func (cc *MsgpackCodec) WriteResponse(r *rpc.Response, body interface{}) error {
 		return io.EOF
 	}
 	if err := cc.enc.Encode(r); err != nil {
+		cc.Close()
 		return err
 	}
 	if err := cc.enc.Encode(body); err != nil {
+		cc.Close()
 		return err
 	}
 	if cc.bufW != nil {
-		return cc.bufW.Flush()
+		if err := cc.bufW.Flush(); err != nil {
+			cc.Close()
+			return err
+		}
 	}
 	return nil
 }
@@ -94,6 +112,12 @@ func (cc *MsgpackCodec) ReadResponseBody(out interface{}) error {
 	return cc.read(out)
 }
 
+// WriteRequest encodes the provided *rpc.Response header and its associated
+// body, writing both to the underlying connection using Msgpack encoding.
+//
+// When WriteRequest returns an error to net/rpc, it is propagated to the
+// caller. This allows the caller to deal with the error unlike how
+// WriteResponse has to close the Codec (and connection).
 func (cc *MsgpackCodec) WriteRequest(r *rpc.Request, body interface{}) error {
 	cc.writeLock.Lock()
 	defer cc.writeLock.Unlock()

--- a/net-rpc-msgpackrpc/codec.go
+++ b/net-rpc-msgpackrpc/codec.go
@@ -71,7 +71,19 @@ func (cc *MsgpackCodec) ReadRequestBody(out interface{}) error {
 func (cc *MsgpackCodec) WriteResponse(r *rpc.Response, body interface{}) error {
 	cc.writeLock.Lock()
 	defer cc.writeLock.Unlock()
-	return cc.write(r, body)
+	if cc.closed {
+		return io.EOF
+	}
+	if err := cc.enc.Encode(r); err != nil {
+		return err
+	}
+	if err := cc.enc.Encode(body); err != nil {
+		return err
+	}
+	if cc.bufW != nil {
+		return cc.bufW.Flush()
+	}
+	return nil
 }
 
 func (cc *MsgpackCodec) ReadResponseHeader(r *rpc.Response) error {
@@ -85,7 +97,19 @@ func (cc *MsgpackCodec) ReadResponseBody(out interface{}) error {
 func (cc *MsgpackCodec) WriteRequest(r *rpc.Request, body interface{}) error {
 	cc.writeLock.Lock()
 	defer cc.writeLock.Unlock()
-	return cc.write(r, body)
+	if cc.closed {
+		return io.EOF
+	}
+	if err := cc.enc.Encode(r); err != nil {
+		return err
+	}
+	if err := cc.enc.Encode(body); err != nil {
+		return err
+	}
+	if cc.bufW != nil {
+		return cc.bufW.Flush()
+	}
+	return nil
 }
 
 func (cc *MsgpackCodec) Close() error {
@@ -94,22 +118,6 @@ func (cc *MsgpackCodec) Close() error {
 	}
 	cc.closed = true
 	return cc.conn.Close()
-}
-
-func (cc *MsgpackCodec) write(obj1, obj2 interface{}) (err error) {
-	if cc.closed {
-		return io.EOF
-	}
-	if err = cc.enc.Encode(obj1); err != nil {
-		return
-	}
-	if err = cc.enc.Encode(obj2); err != nil {
-		return
-	}
-	if cc.bufW != nil {
-		return cc.bufW.Flush()
-	}
-	return
 }
 
 func (cc *MsgpackCodec) read(obj interface{}) (err error) {

--- a/net-rpc-msgpackrpc/codec_test.go
+++ b/net-rpc-msgpackrpc/codec_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MIT
+
+package msgpackrpc
+
+import (
+	"io"
+	"net"
+	"net/rpc"
+	"testing"
+)
+
+// TestMsgpackCodec_RequestResponse verifies that a request sent from a client
+// is correctly read by the server and that a response sent from the server is
+// correctly read by the client. It tests both WriteRequest and WriteResponse
+// (both of which call the internal write() function).
+func TestMsgpackCodec_RequestResponse(t *testing.T) {
+	// Use a table test to try different buffering configurations.
+	tests := []struct {
+		name      string
+		bufReads  bool
+		bufWrites bool
+	}{
+		{"BufferedReadWrite", true, true},
+		{"UnbufferedReadWrite", false, false},
+		{"BufferedReadOnly", true, false},
+		{"BufferedWriteOnly", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a pair of connected endpoints.
+			clientConn, serverConn := net.Pipe()
+			defer clientConn.Close()
+			defer serverConn.Close()
+
+			// Create client and server codecs using the same msgpack handle.
+			clientCodec := NewCodecFromHandle(tt.bufReads, tt.bufWrites, clientConn, msgpackHandle)
+			serverCodec := NewCodecFromHandle(tt.bufReads, tt.bufWrites, serverConn, msgpackHandle)
+
+			// --- Test Request Path ---
+
+			// Prepare a test RPC request.
+			req := &rpc.Request{
+				ServiceMethod: "TestService.TestMethod",
+				Seq:           1,
+			}
+			reqBody := "request payload"
+
+			// Start a goroutine to write the request from the client.
+			reqWriteDone := make(chan error, 1)
+			go func() {
+				err := clientCodec.WriteRequest(req, reqBody)
+				reqWriteDone <- err
+			}()
+
+			// On the server side, read the header and body.
+			var readReq rpc.Request
+			if err := serverCodec.ReadRequestHeader(&readReq); err != nil {
+				t.Fatalf("ReadRequestHeader failed: %v", err)
+			}
+			var readReqBody string
+			if err := serverCodec.ReadRequestBody(&readReqBody); err != nil {
+				t.Fatalf("ReadRequestBody failed: %v", err)
+			}
+			if readReq.ServiceMethod != req.ServiceMethod || readReq.Seq != req.Seq {
+				t.Errorf("Request header mismatch: got %+v, want %+v", readReq, req)
+			}
+			if readReqBody != reqBody {
+				t.Errorf("Request body mismatch: got %q, want %q", readReqBody, reqBody)
+			}
+
+			// Make sure the client's write completed without error.
+			if err := <-reqWriteDone; err != nil {
+				t.Fatalf("WriteRequest failed: %v", err)
+			}
+
+			// --- Test Response Path ---
+
+			// Prepare a test RPC response.
+			resp := &rpc.Response{
+				ServiceMethod: "TestService.TestMethod",
+				Seq:           1,
+			}
+			respBody := "response payload"
+
+			// Start a goroutine to write the response from the server.
+			respWriteDone := make(chan error, 1)
+			go func() {
+				err := serverCodec.WriteResponse(resp, respBody)
+				respWriteDone <- err
+			}()
+
+			// On the client side, read the response header and body.
+			var readResp rpc.Response
+			if err := clientCodec.ReadResponseHeader(&readResp); err != nil {
+				t.Fatalf("ReadResponseHeader failed: %v", err)
+			}
+			var readRespBody string
+			if err := clientCodec.ReadResponseBody(&readRespBody); err != nil {
+				t.Fatalf("ReadResponseBody failed: %v", err)
+			}
+			if readResp.ServiceMethod != resp.ServiceMethod || readResp.Seq != resp.Seq {
+				t.Errorf("Response header mismatch: got %+v, want %+v", readResp, resp)
+			}
+			if readRespBody != respBody {
+				t.Errorf("Response body mismatch: got %q, want %q", readRespBody, respBody)
+			}
+
+			// Ensure the server's write completed successfully.
+			if err := <-respWriteDone; err != nil {
+				t.Fatalf("WriteResponse failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestMsgpackCodec_NilBody verifies that if a nil value is provided for the
+// request body then the codec still performs a decode on the wire. (The
+// implementation of read always attempts to decode even when obj == nil.)
+func TestMsgpackCodec_NilBody(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	clientCodec := NewCodec(true, true, clientConn)
+	serverCodec := NewCodec(true, true, serverConn)
+
+	req := &rpc.Request{
+		ServiceMethod: "TestService.NilMethod",
+		Seq:           2,
+	}
+
+	// Write a request with a nil body.
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- clientCodec.WriteRequest(req, nil)
+	}()
+
+	// Read the header normally.
+	var readReq rpc.Request
+	if err := serverCodec.ReadRequestHeader(&readReq); err != nil {
+		t.Fatalf("ReadRequestHeader failed: %v", err)
+	}
+	// Now read the body; even though we passed nil on the write side, the codec
+	// should attempt to decode the nil value.
+	if err := serverCodec.ReadRequestBody(nil); err != nil {
+		t.Fatalf("ReadRequestBody (with nil) failed: %v", err)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatalf("WriteRequest (with nil body) failed: %v", err)
+	}
+}
+
+// TestMsgpackCodec_Close ensures that once the codec is closed, subsequent
+// reads or writes immediately return io.EOF.
+func TestMsgpackCodec_Close(t *testing.T) {
+	clientConn, _ := net.Pipe()
+	codec := NewCodec(true, true, clientConn)
+
+	// Close the codec.
+	if err := codec.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	// Further write operations should return io.EOF.
+	if err := codec.WriteRequest(&rpc.Request{}, "test"); err != io.EOF {
+		t.Errorf("WriteRequest after Close: got %v, want io.EOF", err)
+	}
+
+	// Further read operations should also return io.EOF.
+	if err := codec.ReadResponseHeader(&rpc.Response{}); err != io.EOF {
+		t.Errorf("ReadResponseHeader after Close: got %v, want io.EOF", err)
+	}
+}


### PR DESCRIPTION
This PR is to bring over the changes made in hashicorp/net-rpc-msgpackrpc#15.

The changes were brought over using `git format-patch master`, then modifying the paths of the affected files in the patch, and applying them with `git am < ...`. This necessitated a commit to move the `MsgpackCodec.SourceAddr` method to the bottom of the file so the patches would apply cleanly.

The rest of the PR text is copied over for completeness's sake.

---

It turns out when `net/rpc` calls `WriteResponse`, it [**doesn't do anything with the error**](https://github.com/golang/go/blob/cb47156e90cac6b1030d747f1ccd433c00494dfc/src/net/rpc/server.go#L359-L362)! (it does correctly propagates errors when `WriteRequest` is called though)

This means this codec needs to handle connection disposal, because there's no way for someone using `net/rpc` to find out about the error and handle it- we're in the twilight zone.

Additionally, because `net/rpc` is frozen upstream, there is a lack of desire to fix even the logging aspect, let alone the underlying defect: golang/go#71559

The `WriteResponse` and `WriteRequest` methods both use the same underlying `write` method, so this fix took three commits-

* adding the first test coverage to this package, to prove de-DRYing doesn't break anything
* de-DRYing by inlining `write` into `WriteResponse` and `WriteRequest`
* the actual fix, along with a test for it

This puts an end to two years of "spooky behaviour at a distance" on our large and geographically distributed Nomad cluster.

I will also be opening a PR against hashicorp/consul-net-rpc for the same code change.

requested tags: @schmichael, @tgross

~Fixes: hashicorp/nomad#23305~ (this is only used in Consul)